### PR TITLE
add script to update arcdps and run launchbuddy

### DIFF
--- a/launcher.cptn.ps1
+++ b/launcher.cptn.ps1
@@ -1,0 +1,4 @@
+$LaunchBuddyPath = "C:\Guild Wars 2\Gw2_Launchbuddy_1.5.2.exe"
+
+& .\update-arcdps.ps1
+Start-Process -FilePath $LaunchBuddyPath

--- a/update-arcdps.ps1
+++ b/update-arcdps.ps1
@@ -158,5 +158,3 @@ if ($run_update -eq $false) {
     Invoke-WebRequest -Uri $mechanics_url -UseBasicParsing -OutFile $mechanics_path
     Copy-Item $mechanics_path $mechanics_bin_path
 }
-
-Read-Host -Prompt "Press Enter to exit"


### PR DESCRIPTION
For those who use launch buddy, add a script which updates arcdps and then runs launch buddy. This helps those who run launch buddy always ensure that arcdps is up to date.