### PR TITLE
Fix name of EVTC files when the files are uncompressed

### DIFF
--- a/l0g-101086.psm1
+++ b/l0g-101086.psm1
@@ -152,10 +152,10 @@ Function Get-UncompressedEVTC-Name {
     param([Parameter(Mandatory)][string]$filename)
 
     if ($filename -Like "*.evtc") {
-        # This filename is uncompressed already
-        return $filename
-    } elseif ($filename -Like "*.evtc") {
-        # We have two extensions, so remove the first one
+        # This filename is already correct, so just strip the directory
+        return [io.path]::GetFileName($filename)
+    } elseif ($filename -Like "*.evtc.zip") {
+        # We have two extensions, so only remove the first one
         return [io.path]::GetFileNameWithoutExtension($filename)
     } elseif ($filename -Like "*.zevtc") {
         # Strip the ".zevtc", and add back ".evtc"


### PR DESCRIPTION
The Get-UncompressedEVTC-Name function did not properly strip the
directory component of files when they were uncompressed. This happened
when we added support for the .zevtc files.

Fix the Get-UncompressedEVTC-Name function to properly strip the directory
component for all returns. Additionally, fix a bug where we check for
*.evtc twice. The second time should have been *.evtc.zip instead.

Signed-off-by: Jacob Keller <jacob.keller@gmail.com>