### PR TITLE
re-write update-arcdps.ps1 to reduce duplicate code

### DIFF
--- a/update-arcdps.ps1
+++ b/update-arcdps.ps1
@@ -110,14 +110,14 @@ ForEach ($f in $files) {
         Log-And-Write-Output "$($f.dll): needs to be updated"
         $f.update = $true
 
-        ForEach ($child in $files.where($_.updatewith -eq $f.dll)) {
+        ForEach ($child in $files.where({$_.updatewith -eq $f.dll})) {
             Log-And-Write-Output "$($child.dll): needs to be updated"
             $child.update = $true
         }
     }
 }
 
-ForEach ($f in $files.where{$_.update -eq $true}) {
+ForEach ($f in $files.where({$_.update -eq $true})) {
     Log-And-Write-Output "$($f.dll): downloading new copy"
 
     # Make a back up of the current dll before overwriting it


### PR DESCRIPTION
Refactor update-arcdps.ps1 to share the code for checking and
downloading the files.

Create an array of hash tables for each extension and the main ArcDPS
dll. Loop over the table to determine which files to update, then loop
over it again to actually update them.

This double-loop is required because the extras and buildtemplate
extensions do not have their own md5 file. If we were to perform each
update in sequence, the md5 check for the templates and extras
extensions would always succeed.

By splitting the question of what to download away from the actual
download, this is prevented.

This change does remove support for downloading the experimental ArcDPS
dlls.

Additionally, it may be a good idea to let users configure the plugins
they wish to install.

Signed-off-by: Jacob Keller <jacob.e.keller@intel.com>