### PR TITLE
Discord API now requires you to set the content-type

### DIFF
--- a/l0g-101086.psm1
+++ b/l0g-101086.psm1
@@ -1648,7 +1648,7 @@ Function Publish-Discord-Embed {
           [Parameter(Mandatory)][string]$embed_string)
 
     # Send this request to the discord webhook
-    Invoke-RestMethod -Uri $guild.webhook_url -Method Post -Body $embed_string
+    Invoke-RestMethod -Uri $guild.webhook_url -Method Post -Body $embed_string -ContentType 'application/json'
 }
 
 <#


### PR DESCRIPTION
The Discord API now requires you to set the content-type when posting to the webhook (I think this was changed late last week). See [this Discord issue comment for more details](https://github.com/discordapp/discord-api-docs/issues/1197#issuecomment-558027645). So now format-encounters.ps1 is failing to post to Discord. By adding the content-type header for application/json it works again.